### PR TITLE
fix(ci): add required enable-versioned-regex input to issue-labeler

### DIFF
--- a/.github/workflows/issue-opened.yaml
+++ b/.github/workflows/issue-opened.yaml
@@ -13,3 +13,4 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler-issue-triage.yml
+        enable-versioned-regex: 0


### PR DESCRIPTION
## Summary

Fixes failing issue triage workflow caused by missing required input.

## Problem

The `github/issue-labeler` action now requires the `enable-versioned-regex` input to be explicitly set:
```
Error: Input required and not supplied: enable-versioned-regex
```

See failed run: https://github.com/JohanVanosmaelAcerta/terraform-provider-windowsad/actions/runs/21227237214/job/61077310462

## Changes

Added `enable-versioned-regex: 0` to the issue-labeler step to disable versioned regex matching.

## Testing

- [ ] Workflow runs successfully after merge