### PR TITLE
feat(user): add name property for AD user objects

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -70,6 +70,7 @@ output "testuser_guid" {
 - `home_phone` (String) Home phone of the user object.
 - `initials` (String) Initials of the user object.
 - `mobile_phone` (String) Mobile phone of the user object.
+- `name` (String) The name of the user object (CN).
 - `office` (String) Office assigned to user object.
 - `office_phone` (String) Office phone of the user object.
 - `organization` (String) Organization assigned to user object.

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -27,6 +27,16 @@ resource "windowsad_user" "u" {
   })
 }
 
+# example with custom name (CN)
+resource "windowsad_user" "with_custom_name" {
+  principal_name   = "jsmith@example.com"
+  sam_account_name = "jsmith"
+  display_name     = "John Smith"
+  name             = "Smith, John"  # Custom CN instead of "jsmith"
+  given_name       = "John"
+  surname          = "Smith"
+}
+
 
 # all user attributes
 variable principal_name2 { default = "testuser2" }
@@ -105,6 +115,7 @@ resource "windowsad_user" "u2" {
 - `initial_password` (String) The user's initial password. This will be set on creation but will *not* be enforced in subsequent plans.
 - `initials` (String) Specifies the initials that represent part of a user's name. Maximum 6 char.
 - `mobile_phone` (String) Specifies the user's mobile phone number. This parameter sets the MobilePhone property of a user object.
+- `name` (String) The name of the user object (CN). If not specified, defaults to the username portion of principal_name.
 - `office` (String) Specifies the location of the user's office or place of business. This parameter sets the Office property of a user object.
 - `office_phone` (String) Specifies the user's office telephone number. This parameter sets the OfficePhone property of a user object.
 - `organization` (String) Specifies the user's organization. This parameter sets the Organization property of a user object.

--- a/windowsad/data_source_ad_user.go
+++ b/windowsad/data_source_ad_user.go
@@ -20,6 +20,11 @@ func dataSourceADUser() *schema.Resource {
 				Required:    true,
 				Description: "The user's identifier. It can be the group's GUID, SID, Distinguished Name, or SAM Account Name.",
 			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the user object (CN).",
+			},
 			"sam_account_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -204,6 +209,7 @@ func dataSourceADUserRead(d *schema.ResourceData, meta interface{}) error {
 	if u == nil {
 		return fmt.Errorf("No user found with user_id %q", userID)
 	}
+	_ = d.Set("name", u.Name)
 	_ = d.Set("sam_account_name", u.SAMAccountName)
 	_ = d.Set("display_name", u.DisplayName)
 	_ = d.Set("principal_name", u.PrincipalName)

--- a/windowsad/internal/winrmhelper/winrm_user.go
+++ b/windowsad/internal/winrmhelper/winrm_user.go
@@ -17,6 +17,7 @@ import (
 // User represents an AD User
 type User struct {
 	GUID                   string `json:"ObjectGUID"`
+	Name                   string `json:"Name"`
 	SAMAccountName         string `json:"SamAccountName"`
 	PrincipalName          string `json:"UserPrincipalName"`
 	City                   string
@@ -69,7 +70,12 @@ func (u *User) NewUser(conf *config.ProviderConf) (string, error) {
 	}
 
 	log.Printf("Adding user with UPN: %q", u.PrincipalName)
-	cmds := []string{fmt.Sprintf("New-ADUser -Passthru -Name %q", u.Username)}
+	// Use Name if provided, otherwise fall back to Username (derived from UPN)
+	name := u.Name
+	if name == "" {
+		name = u.Username
+	}
+	cmds := []string{fmt.Sprintf("New-ADUser -Passthru -Name %q", name)}
 
 	cmds = append(cmds, fmt.Sprintf("-CannotChangePassword $%t", u.CannotChangePassword))
 	cmds = append(cmds, fmt.Sprintf("-PasswordNeverExpires $%t", u.PasswordNeverExpires))
@@ -450,6 +456,28 @@ func (u *User) ModifyUser(d *schema.ResourceData, conf *config.ProviderConf) err
 		}
 	}
 
+	if d.HasChange("name") {
+		newName := d.Get("name").(string)
+		cmd := fmt.Sprintf("Rename-ADObject -Identity %q -NewName %q", u.GUID, newName)
+		psOpts := CreatePSCommandOpts{
+			JSONOutput:      false,
+			ForceArray:      false,
+			ExecLocally:     conf.IsConnectionTypeLocal(),
+			PassCredentials: conf.IsPassCredentialsEnabled(),
+			Username:        conf.Settings.WinRMUsername,
+			Password:        conf.Settings.WinRMPassword,
+			Server:          conf.IdentifyDomainController(),
+		}
+		psCmd := NewPSCommand([]string{cmd}, psOpts)
+		result, err := psCmd.Run(conf)
+		if err != nil {
+			return fmt.Errorf("winrm execution failure while renaming user object: %s", err)
+		}
+		if result.ExitCode != 0 {
+			return fmt.Errorf("Rename-ADObject exited with a non zero exit code (%d), stderr: %s", result.ExitCode, result.StdErr)
+		}
+	}
+
 	return nil
 }
 
@@ -503,6 +531,7 @@ func (u *User) getOtherAttributes() (string, error) {
 func GetUserFromResource(d *schema.ResourceData) (*User, error) {
 	user := User{
 		GUID:                   d.Id(),
+		Name:                   SanitiseTFInput(d, "name"),
 		SAMAccountName:         SanitiseTFInput(d, "sam_account_name"),
 		PrincipalName:          SanitiseTFInput(d, "principal_name"),
 		DisplayName:            SanitiseTFInput(d, "display_name"),

--- a/windowsad/resource_ad_user.go
+++ b/windowsad/resource_ad_user.go
@@ -26,6 +26,12 @@ func resourceADUser() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The name of the user object (CN). If not specified, defaults to the username portion of principal_name.",
+			},
 			"display_name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -304,6 +310,7 @@ func resourceADUserRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	}
+	_ = d.Set("name", u.Name)
 	_ = d.Set("sam_account_name", u.SAMAccountName)
 	_ = d.Set("display_name", u.DisplayName)
 	_ = d.Set("principal_name", u.PrincipalName)


### PR DESCRIPTION
## Summary

Port upstream PR [hashicorp/terraform-provider-ad#130](https://github.com/hashicorp/terraform-provider-ad/pull/130) to add a `name` property to user resources.

## Context

Currently the AD user object's `Name` attribute (the CN) is automatically set to the username portion of `principal_name`. Users cannot specify a custom display name for the AD object itself.

## Changes

### `windowsad/internal/winrmhelper/winrm_user.go`
- Add `Name` field to `User` struct with JSON tag
- Update `NewUser` to use `Name` if provided, else fall back to `Username`
- Add `Rename-ADObject` logic in `ModifyUser` for name changes
- Update `GetUserFromResource` to read name from state

### `windowsad/resource_ad_user.go`
- Add `name` schema (Optional, Computed)
- Update read function to set name in state

### `windowsad/data_source_ad_user.go`
- Add `name` schema (Computed)
- Update read function to set name

### Documentation
- Add `name` attribute to resource and data source docs
- Add example showing custom name usage

## Testing

- [x] `go build ./...` - passes
- [x] `go test ./...` - passes
- [ ] Acceptance tests (will run via CI)

## Example Usage

```hcl
resource "windowsad_user" "with_custom_name" {
  principal_name   = "jsmith@example.com"
  sam_account_name = "jsmith"
  display_name     = "John Smith"
  name             = "Smith, John"  # Custom CN instead of "jsmith"
  given_name       = "John"
  surname          = "Smith"
}
```

## Upstream Reference

- PR: https://github.com/hashicorp/terraform-provider-ad/pull/130
- Lines changed: +55/-1

Closes #2