### PR TITLE
ci: run acceptance tests in 3 parallel groups

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -9,12 +9,25 @@ on:
 
 jobs:
   acceptance-tests:
-    name: Acceptance Tests
+    name: ${{ matrix.name }}
     # Skip for PRs from forks - they don't have access to secrets and
     # we don't want to expose internal infrastructure in logs
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, Windows, X64]
-    timeout-minutes: 60
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Group 1: GPO-related tests (gpo, gplink, gpo_security)
+          - name: "GPO Tests"
+            test_pattern: "TestAcc.*(GPO|GPLink|GPSecurity)"
+          # Group 2: User and Group tests (user, group, group_membership)
+          - name: "User & Group Tests"
+            test_pattern: "TestAcc.*(User|Group)"
+          # Group 3: Computer and OU tests (computer, ou)
+          - name: "Computer & OU Tests"
+            test_pattern: "TestAcc.*(Computer|OU)"
     env:
       TF_ACC: 1
       WINDOWSAD_HOSTNAME: ${{ secrets.AD_HOSTNAME }}
@@ -162,8 +175,9 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path $env:GOCACHE | Out-Null
           New-Item -ItemType Directory -Force -Path $env:GOTMPDIR | Out-Null
-          Write-Host "=== Starting acceptance tests at $(Get-Date) ==="
+          Write-Host "=== Starting ${{ matrix.name }} at $(Get-Date) ==="
+          Write-Host "Test pattern: ${{ matrix.test_pattern }}"
           Write-Host "TF_ACC=$env:TF_ACC"
           Write-Host "WINDOWSAD_HOSTNAME=$env:WINDOWSAD_HOSTNAME"
-          # Run all acceptance tests
-          go test ./windowsad -v -count=1 -parallel=1 -timeout=45m -run "TestAcc" 2>&1 | ForEach-Object { "[$(Get-Date -Format 'HH:mm:ss')] $_" }
+          # Run tests matching this group's pattern
+          go test ./windowsad -v -count=1 -parallel=1 -timeout=30m -run "${{ matrix.test_pattern }}" 2>&1 | ForEach-Object { "[$(Get-Date -Format 'HH:mm:ss')] $_" }


### PR DESCRIPTION
## Summary

Split acceptance tests into 3 parallel matrix jobs to reduce total runtime.

## Changes

Updated `.github/workflows/acceptance-tests.yml` to use a matrix strategy:

| Group | Test Pattern | Tests |
|-------|--------------|-------|
| **GPO Tests** | `TestAcc.*(GPO\|GPLink\|GPSecurity)` | 7 tests |
| **User & Group Tests** | `TestAcc.*(User\|Group)` | 12 tests |
| **Computer & OU Tests** | `TestAcc.*(Computer\|OU)` | 8 tests |

## Expected Results

| Metric | Before | After |
|--------|--------|-------|
| Total runtime | ~30-45 min | ~10-15 min |
| Jobs | 1 sequential | 3 parallel |
| Timeout per job | 60 min | 45 min |

## Technical Details

- Uses `strategy.matrix.include` to define test groups
- Each group runs `-parallel=1` internally (sequential within group)
- `fail-fast: false` ensures all groups complete even if one fails
- Each job runs on `[self-hosted, Windows, X64]` runner
- Tests use random names so there's no conflict between groups

## Testing

The PR itself will trigger the new parallel workflow, validating the approach.

## Notes

- GPO tests will still fail until service account is added to "Group Policy Creator Owners"
- User/Group and Computer/OU tests should pass